### PR TITLE
feat: 人口カテゴリ切り替え機能の実装およびコードフォーマットの適用

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,8 @@
     "semi": true,
     "singleQuote": true,
     "printWidth": 80,
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "arrowParens": "always"
   }
   

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,22 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
-
+import globals from 'globals';
+import pluginJs from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import pluginReact from 'eslint-plugin-react';
 
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {languageOptions: { globals: globals.browser }},
+  { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
+  { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
+  {
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    rules: {
+      'react/react-in-jsx-scope': 'off',
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "globals": "^15.9.0",
         "jsdom": "^25.0.0",
         "prettier": "^3.3.3",
-        "typescript": "^5.5.3",
+        "typescript": "5.5.3",
         "typescript-eslint": "^8.5.0",
         "vite": "^5.4.1",
         "vitest": "^2.1.0"
@@ -6216,9 +6216,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier --write 'src/**/*.{js,ts,tsx,jsx,css,md}'"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -34,7 +35,7 @@
     "globals": "^15.9.0",
     "jsdom": "^25.0.0",
     "prettier": "^3.3.3",
-    "typescript": "^5.5.3",
+    "typescript": "5.5.3",
     "typescript-eslint": "^8.5.0",
     "vite": "^5.4.1",
     "vitest": "^2.1.0"

--- a/src/App.css
+++ b/src/App.css
@@ -37,6 +37,33 @@ label {
     white-space: nowrap;
 }
 
+.category-buttons {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.category-buttons button {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    background-color: white;
+    cursor: pointer;
+    transition: background-color 0.3s, font-weight 0.3s;
+    flex: 1 1 100px;
+}
+
+.category-buttons button:hover {
+    background-color: #f0f0f0;
+}
+
+.category-buttons button.active {
+    font-weight: bold;
+    background-color: #e0e0e0;
+}
+
 @media (min-width: 768px) {
     html {
         font-size: 16px;
@@ -53,6 +80,15 @@ label {
 
     label {
         font-size: 1.125rem;
+    }
+
+    .category-buttons {
+        gap: 1rem;
+    }
+
+    .category-buttons button {
+        font-size: 1.125rem;
+        flex: 1 1 150px;
     }
 }
 
@@ -72,5 +108,10 @@ label {
 
     label {
         font-size: 1.25rem;
+    }
+
+    .category-buttons button {
+        font-size: 1.25rem;
+        flex: 1 1 200px;
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,117 +1,119 @@
 html {
-    font-size: 14px;
+  font-size: 14px;
 }
 body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 1rem;
-    background-color: #f9f9f9;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background-color: #f9f9f9;
 }
 
 h1 {
-    font-size: 2rem;
-    text-align: center;
-    margin-bottom: 1.5rem;
+  font-size: 2rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
 }
 
 ul {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-    gap: 0.5rem;
-    list-style-type: none;
-    padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.5rem;
+  list-style-type: none;
+  padding: 0;
 }
 
 li {
-    margin-bottom: 0.5rem;
-    display: flex;
-    align-items: center;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
 }
 
-input[type="checkbox"] {
-    margin-right: 0.5rem;
+input[type='checkbox'] {
+  margin-right: 0.5rem;
 }
 
 label {
-    font-size: 1rem;
-    white-space: nowrap;
+  font-size: 1rem;
+  white-space: nowrap;
 }
 
 .category-buttons {
-    margin-top: 1rem;
-    display: flex;
-    justify-content: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .category-buttons button {
-    padding: 0.5rem 1rem;
-    font-size: 1rem;
-    border: 1px solid #ccc;
-    background-color: white;
-    cursor: pointer;
-    transition: background-color 0.3s, font-weight 0.3s;
-    flex: 1 1 100px;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  background-color: white;
+  cursor: pointer;
+  transition:
+    background-color 0.3s,
+    font-weight 0.3s;
+  flex: 1 1 100px;
 }
 
 .category-buttons button:hover {
-    background-color: #f0f0f0;
+  background-color: #f0f0f0;
 }
 
 .category-buttons button.active {
-    font-weight: bold;
-    background-color: #e0e0e0;
+  font-weight: bold;
+  background-color: #e0e0e0;
 }
 
 @media (min-width: 768px) {
-    html {
-        font-size: 16px;
-    }
+  html {
+    font-size: 16px;
+  }
 
-    h1 {
-        font-size: 2.5rem;
-        margin-bottom: 2rem;
-    }
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+  }
 
-    li {
-        margin-bottom: 1.5rem;
-    }
+  li {
+    margin-bottom: 1.5rem;
+  }
 
-    label {
-        font-size: 1.125rem;
-    }
+  label {
+    font-size: 1.125rem;
+  }
 
-    .category-buttons {
-        gap: 1rem;
-    }
+  .category-buttons {
+    gap: 1rem;
+  }
 
-    .category-buttons button {
-        font-size: 1.125rem;
-        flex: 1 1 150px;
-    }
+  .category-buttons button {
+    font-size: 1.125rem;
+    flex: 1 1 150px;
+  }
 }
 
 @media (min-width: 1024px) {
-    html {
-        font-size: 18px;
-    }
+  html {
+    font-size: 18px;
+  }
 
-    body{
-        max-width: 800px;
-        margin: 0 auto;
-    }
+  body {
+    max-width: 800px;
+    margin: 0 auto;
+  }
 
-    h1 {
-        font-size: 3rem;
-    }
+  h1 {
+    font-size: 3rem;
+  }
 
-    label {
-        font-size: 1.25rem;
-    }
+  label {
+    font-size: 1.25rem;
+  }
 
-    .category-buttons button {
-        font-size: 1.25rem;
-        flex: 1 1 200px;
-    }
+  .category-buttons button {
+    font-size: 1.25rem;
+    flex: 1 1 200px;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,15 +9,25 @@ const App: React.FC = () => {
   const { prefectures, error } = useFetchPrefectures();
   const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]);
   const { populationData, fetchPopulationData } = usePopulationData();
+  const [populationCategory, setPopulationCategory] =
+    useState<string>('総人口');
 
   const handleCheckboxChange = (prefCode: number) => {
     setSelectedPrefectures((prevSelected) => {
       if (prevSelected.includes(prefCode)) {
         return prevSelected.filter((code) => code !== prefCode);
       } else {
-        fetchPopulationData(prefCode);
+        fetchPopulationData(prefCode, populationCategory);
         return [...prevSelected, prefCode];
       }
+    });
+  };
+
+  const handleCategoryChange = (category: string) => {
+    setPopulationCategory(category);
+
+    selectedPrefectures.forEach((prefCode) => {
+      fetchPopulationData(prefCode, category);
     });
   };
 
@@ -33,6 +43,35 @@ const App: React.FC = () => {
         selectedPrefectures={selectedPrefectures}
         onCheckboxChange={handleCheckboxChange}
       />
+
+      {/* カテゴリを選択するUIをボタンで表示 */}
+      <div className="category-buttons">
+        <button
+          className={populationCategory === '総人口' ? 'active' : ''}
+          onClick={() => handleCategoryChange('総人口')}
+        >
+          総人口
+        </button>
+        <button
+          className={populationCategory === '年少人口' ? 'active' : ''}
+          onClick={() => handleCategoryChange('年少人口')}
+        >
+          年少人口
+        </button>
+        <button
+          className={populationCategory === '生産年齢人口' ? 'active' : ''}
+          onClick={() => handleCategoryChange('生産年齢人口')}
+        >
+          生産年齢人口
+        </button>
+        <button
+          className={populationCategory === '老年人口' ? 'active' : ''}
+          onClick={() => handleCategoryChange('老年人口')}
+        >
+          老年人口
+        </button>
+      </div>
+
       <PopulationDataDisplay
         selectedPrefectures={selectedPrefectures}
         prefectures={prefectures}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,52 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import './App.css';
-
-type Prefecture = {
-  prefCode: number;
-  prefName: string;
-};
-
-type PopulationData = {
-  year: number;
-  value: number;
-};
+import PrefectureCheckboxList from './components/PrefectureCheckboxList';
+import PopulationDataDisplay from './components/PopulationDataDisplay';
+import useFetchPrefectures from './hooks/useFetchPrefectures';
+import usePopulationData from './hooks/usePopulationData';
 
 const App: React.FC = () => {
-  const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
+  const { prefectures, error } = useFetchPrefectures();
   const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]);
-  const [populationData, setPopulationData] = useState<Record<number, PopulationData[]>>({});
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchPrefectures = async () => {
-      try {
-        const response = await fetch('https://opendata.resas-portal.go.jp/api/v1/prefectures', {
-          headers: {
-            'X-API-KEY': import.meta.env.VITE_RESAS_API_KEY,
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error('Failed to fetch prefectures');
-        }
-        
-        const data = await response.json();
-        setPrefectures(data.result);
-      } catch (err) {
-        if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError('An unknown error occurred');
-        }
-      }
-    }
-
-    fetchPrefectures();
-  }, []);
+  const { populationData, fetchPopulationData } = usePopulationData();
 
   const handleCheckboxChange = (prefCode: number) => {
     setSelectedPrefectures((prevSelected) => {
-      if (prevSelected.includes(prefCode)){
+      if (prevSelected.includes(prefCode)) {
         return prevSelected.filter((code) => code !== prefCode);
       } else {
         fetchPopulationData(prefCode);
@@ -55,58 +21,23 @@ const App: React.FC = () => {
     });
   };
 
-  const fetchPopulationData = async (prefCode: number) => {
-    try {
-      const response = await fetch(
-        `https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?prefCode=${prefCode}`, 
-        {
-          headers: {
-            'X-API-KEY': import.meta.env.VITE_RESAS_API_KEY,
-          },
-        }
-      );
-      if(!response.ok) {
-        throw new Error('Failed to fetch population data');
-      }
-
-      const data = await response.json();
-      setPopulationData((prevData) => ({
-        ...prevData,
-        [prefCode]: data.result.data[0].data,
-      }));
-    } catch (err) {
-      console.error('Error fetching population data:', err);
-    }
-  };
-
   if (error) {
-    return <div>Error: {error}</div>
+    return <div>Error: {error}</div>;
   }
 
   return (
     <div>
       <h1>都道府県一覧</h1>
-      <ul>
-        {prefectures.map((prefecture) => (
-          <li key={prefecture.prefCode}>
-            <input type="checkbox" id={`pref-${prefecture.prefCode}`} checked={selectedPrefectures.includes(prefecture.prefCode) || false} onChange={() => handleCheckboxChange(prefecture.prefCode)}/>
-            <label htmlFor={`pref-${prefecture.prefCode}`}>{prefecture.prefName}</label>
-          </li>
-        ))}
-      </ul>
-      <div>
-        <h2>人口データ：</h2>
-        {selectedPrefectures.map((prefCode) => (
-          <div key={prefCode}>
-            <h3>{prefectures.find((pref) => pref.prefCode === prefCode)?.prefName}</h3>
-            <ul>
-              {populationData[prefCode]?.map((pop) => (
-                <li key={pop.year}>{pop.year}: {pop.value}</li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
+      <PrefectureCheckboxList
+        prefectures={prefectures}
+        selectedPrefectures={selectedPrefectures}
+        onCheckboxChange={handleCheckboxChange}
+      />
+      <PopulationDataDisplay
+        selectedPrefectures={selectedPrefectures}
+        prefectures={prefectures}
+        populationData={populationData}
+      />
     </div>
   );
 };

--- a/src/components/PopulationDataDisplay.tsx
+++ b/src/components/PopulationDataDisplay.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+type PopulationData = {
+  year: number;
+  value: number;
+};
+
+type PopulationDataDisplayProps = {
+  selectedPrefectures: number[];
+  prefectures: { prefCode: number; prefName: string }[];
+  populationData: Record<number, PopulationData[]>;
+};
+
+const PopulationDataDisplay: React.FC<PopulationDataDisplayProps> = ({
+  selectedPrefectures,
+  prefectures,
+  populationData,
+}) => {
+  return (
+    <div>
+      <h2>人口データ：</h2>
+      {selectedPrefectures.map((prefCode) => (
+        <div key={prefCode}>
+          <h3>{prefectures.find((pref) => pref.prefCode === prefCode)?.prefName}</h3>
+          <ul>
+            {populationData[prefCode]?.map((pop) => (
+              <li key={pop.year}>
+                {pop.year}: {pop.value}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PopulationDataDisplay;

--- a/src/components/PopulationDataDisplay.tsx
+++ b/src/components/PopulationDataDisplay.tsx
@@ -21,7 +21,9 @@ const PopulationDataDisplay: React.FC<PopulationDataDisplayProps> = ({
       <h2>人口データ：</h2>
       {selectedPrefectures.map((prefCode) => (
         <div key={prefCode}>
-          <h3>{prefectures.find((pref) => pref.prefCode === prefCode)?.prefName}</h3>
+          <h3>
+            {prefectures.find((pref) => pref.prefCode === prefCode)?.prefName}
+          </h3>
           <ul>
             {populationData[prefCode]?.map((pop) => (
               <li key={pop.year}>

--- a/src/components/PrefectureCheckboxList.tsx
+++ b/src/components/PrefectureCheckboxList.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+type Prefecture = {
+    prefCode: number;
+    prefName: string;
+};
+
+type PrefectureCheckboxListProps = {
+    prefectures: Prefecture[];
+    selectedPrefectures: number[];
+    onCheckboxChange: (prefCode: number) => void;
+};
+
+const PrefectureCheckboxList: React.FC<PrefectureCheckboxListProps> = ({ prefectures, selectedPrefectures, onCheckboxChange}) => {
+    return (
+        <ul>
+            {prefectures.map((prefecture) => (
+                <li key={prefecture.prefCode}>
+                    <input type="checkbox" id={`pref-${prefecture.prefCode}`} checked={selectedPrefectures.includes(prefecture.prefCode) || false}
+                    onChange={() => onCheckboxChange(prefecture.prefCode)}
+                    />
+                    <label htmlFor={`pref-${prefecture.prefCode}`}>{prefecture.prefName}</label>
+                </li>
+            ))}
+        </ul>
+    );
+};
+
+export default PrefectureCheckboxList;

--- a/src/components/PrefectureCheckboxList.tsx
+++ b/src/components/PrefectureCheckboxList.tsx
@@ -1,29 +1,38 @@
 import React from 'react';
 
 type Prefecture = {
-    prefCode: number;
-    prefName: string;
+  prefCode: number;
+  prefName: string;
 };
 
 type PrefectureCheckboxListProps = {
-    prefectures: Prefecture[];
-    selectedPrefectures: number[];
-    onCheckboxChange: (prefCode: number) => void;
+  prefectures: Prefecture[];
+  selectedPrefectures: number[];
+  onCheckboxChange: (prefCode: number) => void;
 };
 
-const PrefectureCheckboxList: React.FC<PrefectureCheckboxListProps> = ({ prefectures, selectedPrefectures, onCheckboxChange}) => {
-    return (
-        <ul>
-            {prefectures.map((prefecture) => (
-                <li key={prefecture.prefCode}>
-                    <input type="checkbox" id={`pref-${prefecture.prefCode}`} checked={selectedPrefectures.includes(prefecture.prefCode) || false}
-                    onChange={() => onCheckboxChange(prefecture.prefCode)}
-                    />
-                    <label htmlFor={`pref-${prefecture.prefCode}`}>{prefecture.prefName}</label>
-                </li>
-            ))}
-        </ul>
-    );
+const PrefectureCheckboxList: React.FC<PrefectureCheckboxListProps> = ({
+  prefectures,
+  selectedPrefectures,
+  onCheckboxChange,
+}) => {
+  return (
+    <ul>
+      {prefectures.map((prefecture) => (
+        <li key={prefecture.prefCode}>
+          <input
+            type="checkbox"
+            id={`pref-${prefecture.prefCode}`}
+            checked={selectedPrefectures.includes(prefecture.prefCode) || false}
+            onChange={() => onCheckboxChange(prefecture.prefCode)}
+          />
+          <label htmlFor={`pref-${prefecture.prefCode}`}>
+            {prefecture.prefName}
+          </label>
+        </li>
+      ))}
+    </ul>
+  );
 };
 
 export default PrefectureCheckboxList;

--- a/src/hooks/useFetchPrefectures.ts
+++ b/src/hooks/useFetchPrefectures.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+
+type Prefecture = {
+  prefCode: number;
+  prefName: string;
+};
+
+const useFetchPrefectures = () => {
+  const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPrefectures = async () => {
+      try {
+        const response = await fetch('https://opendata.resas-portal.go.jp/api/v1/prefectures', {
+          headers: {
+            'X-API-KEY': import.meta.env.VITE_RESAS_API_KEY,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch prefectures');
+        }
+
+        const data = await response.json();
+        setPrefectures(data.result);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('An unknown error occurred');
+        }
+      }
+    };
+
+    fetchPrefectures();
+  }, []);
+
+  return { prefectures, error };
+};
+
+export default useFetchPrefectures;

--- a/src/hooks/useFetchPrefectures.ts
+++ b/src/hooks/useFetchPrefectures.ts
@@ -12,11 +12,14 @@ const useFetchPrefectures = () => {
   useEffect(() => {
     const fetchPrefectures = async () => {
       try {
-        const response = await fetch('https://opendata.resas-portal.go.jp/api/v1/prefectures', {
-          headers: {
-            'X-API-KEY': import.meta.env.VITE_RESAS_API_KEY,
-          },
-        });
+        const response = await fetch(
+          'https://opendata.resas-portal.go.jp/api/v1/prefectures',
+          {
+            headers: {
+              'X-API-KEY': import.meta.env.VITE_RESAS_API_KEY,
+            },
+          }
+        );
 
         if (!response.ok) {
           throw new Error('Failed to fetch prefectures');

--- a/src/hooks/usePopulationData.ts
+++ b/src/hooks/usePopulationData.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+type PopulationData = {
+  year: number;
+  value: number;
+};
+
+const usePopulationData = () => {
+  const [populationData, setPopulationData] = useState<Record<number, PopulationData[]>>({});
+
+  const fetchPopulationData = async (prefCode: number) => {
+    try {
+      const response = await fetch(
+        `https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?prefCode=${prefCode}`,
+        {
+          headers: {
+            'X-API-KEY': import.meta.env.VITE_RESAS_API_KEY,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch population data');
+      }
+
+      const data = await response.json();
+      setPopulationData((prevData) => ({
+        ...prevData,
+        [prefCode]: data.result.data[0].data,
+      }));
+    } catch (err) {
+      console.error('Error fetching population data:', err);
+    }
+  };
+
+  return { populationData, fetchPopulationData };
+};
+
+export default usePopulationData;

--- a/src/hooks/usePopulationData.ts
+++ b/src/hooks/usePopulationData.ts
@@ -8,7 +8,7 @@ type PopulationData = {
 const usePopulationData = () => {
   const [populationData, setPopulationData] = useState<Record<number, PopulationData[]>>({});
 
-  const fetchPopulationData = async (prefCode: number) => {
+  const fetchPopulationData = async (prefCode: number, category: string) => {
     try {
       const response = await fetch(
         `https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?prefCode=${prefCode}`,
@@ -24,9 +24,27 @@ const usePopulationData = () => {
       }
 
       const data = await response.json();
+
+      let categoryIndex: number;
+      switch (category) {
+        case '年少人口':
+          categoryIndex = 1;
+          break;
+        case '生産年齢人口':
+          categoryIndex = 2;
+          break;
+        case '老年人口':
+          categoryIndex = 3;
+          break;
+        default:
+          categoryIndex = 0;
+      }
+
+      const populationCategoryData = data.result.data[categoryIndex].data;
+
       setPopulationData((prevData) => ({
         ...prevData,
-        [prefCode]: data.result.data[0].data,
+        [prefCode]: populationCategoryData,
       }));
     } catch (err) {
       console.error('Error fetching population data:', err);

--- a/src/hooks/usePopulationData.ts
+++ b/src/hooks/usePopulationData.ts
@@ -6,7 +6,9 @@ type PopulationData = {
 };
 
 const usePopulationData = () => {
-  const [populationData, setPopulationData] = useState<Record<number, PopulationData[]>>({});
+  const [populationData, setPopulationData] = useState<
+    Record<number, PopulationData[]>
+  >({});
 
   const fetchPopulationData = async (prefCode: number, category: string) => {
     try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-)
+  </StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,8 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "jsx": "react-jsx",
+  }
 }


### PR DESCRIPTION
## 概要
RESAS APIから取得した人口データに基づき、人口カテゴリ（総人口、年少人口、生産年齢人口、老年人口）を切り替えて表示する機能を実装しました。また、コード全体にLintとフォーマットを適用して、スタイルの統一とエラー修正を行いました。

### 対応する Issue
- Closes #3 

### 実装内容
1. **人口カテゴリ切り替え機能の追加**
   - 「総人口」「年少人口」「生産年齢人口」「老年人口」の4つの人口カテゴリを切り替えて表示できるUIを実装。
   - 都道府県を選択した際に、該当する人口データが動的に表示される。

2. **コードのLint適用およびフォーマット**
   - ESLintを用いた静的解析を実施し、コード内の問題点を修正。
   - Prettierでコード全体のフォーマットを適用し、スタイルを統一。

### 受け入れ条件
- [x] 各人口カテゴリが正しく切り替わり、該当する人口データが表示されること。
- [x] コードフォーマットが適用され、Lintエラーが発生していないこと。