### PR TITLE
feat: 人口データのグラフ表示機能とレスポンシブ対応を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "recharts": "^2.12.7",
+        "recharts": "^2.13.0-alpha.5",
         "styled-components": "^6.1.13"
       },
       "devDependencies": {
@@ -5356,15 +5356,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.12.7",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
-      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+      "version": "2.13.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.13.0-alpha.5.tgz",
+      "integrity": "sha512-mm8ORfDusDhyWlrY/2NntUAsNeYukteplvRqKGkBEmqNPwqYq9GoEzaVsVDYj8bjGSKJynWGhjEO1NFcntl29g==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
-        "react-is": "^16.10.2",
+        "react-is": "^18.3.1",
         "react-smooth": "^4.0.0",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
@@ -5386,6 +5386,12 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-responsive": "^10.0.0",
         "recharts": "^2.13.0-alpha.5",
         "styled-components": "^6.1.13"
       },
@@ -2579,6 +2580,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "license": "BSD"
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -4024,6 +4031,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4747,6 +4760,15 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/matchmediaquery": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+      "integrity": "sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5324,6 +5346,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-responsive": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.0.tgz",
+      "integrity": "sha512-N6/UiRLGQyGUqrarhBZmrSmHi2FXSD++N5VbSKsBBvWfG0ZV7asvUBluSv5lSzdMyEVjzZ6Y8DL4OHABiztDOg==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.4.2",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
@@ -5676,6 +5716,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/shallow-equal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
+      "license": "MIT"
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-responsive": "^10.0.0",
     "recharts": "^2.13.0-alpha.5",
     "styled-components": "^6.1.13"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "recharts": "^2.12.7",
+    "recharts": "^2.13.0-alpha.5",
     "styled-components": "^6.1.13"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './App.css';
+import LoadingDots from './components/LoadingDots';
 import PrefectureCheckboxList from './components/PrefectureCheckboxList';
 import PopulationDataDisplay from './components/PopulationDataDisplay';
 import useFetchPrefectures from './hooks/useFetchPrefectures';
@@ -11,6 +12,13 @@ const App: React.FC = () => {
   const { populationData, fetchPopulationData } = usePopulationData();
   const [populationCategory, setPopulationCategory] =
     useState<string>('総人口');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (prefectures.length > 0) {
+      setIsLoading(false);
+    }
+  }, [prefectures]);
 
   const handleCheckboxChange = (prefCode: number) => {
     setSelectedPrefectures((prevSelected) => {
@@ -38,45 +46,53 @@ const App: React.FC = () => {
   return (
     <div>
       <h1>都道府県一覧</h1>
-      <PrefectureCheckboxList
-        prefectures={prefectures}
-        selectedPrefectures={selectedPrefectures}
-        onCheckboxChange={handleCheckboxChange}
-      />
 
-      {/* カテゴリを選択するUIをボタンで表示 */}
-      <div className="category-buttons">
-        <button
-          className={populationCategory === '総人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('総人口')}
-        >
-          総人口
-        </button>
-        <button
-          className={populationCategory === '年少人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('年少人口')}
-        >
-          年少人口
-        </button>
-        <button
-          className={populationCategory === '生産年齢人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('生産年齢人口')}
-        >
-          生産年齢人口
-        </button>
-        <button
-          className={populationCategory === '老年人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('老年人口')}
-        >
-          老年人口
-        </button>
-      </div>
+      {isLoading ? (
+        <LoadingDots />
+      ) : (
+        <>
+          <PrefectureCheckboxList
+            prefectures={prefectures}
+            selectedPrefectures={selectedPrefectures}
+            onCheckboxChange={handleCheckboxChange}
+          />
 
-      <PopulationDataDisplay
-        selectedPrefectures={selectedPrefectures}
-        prefectures={prefectures}
-        populationData={populationData}
-      />
+          {/* カテゴリを選択するUIをボタンで表示 */}
+          <div className="category-buttons">
+            <button
+              className={populationCategory === '総人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('総人口')}
+            >
+              総人口
+            </button>
+            <button
+              className={populationCategory === '年少人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('年少人口')}
+            >
+              年少人口
+            </button>
+            <button
+              className={populationCategory === '生産年齢人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('生産年齢人口')}
+            >
+              生産年齢人口
+            </button>
+            <button
+              className={populationCategory === '老年人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('老年人口')}
+            >
+              老年人口
+            </button>
+          </div>
+
+          <PopulationDataDisplay
+            selectedPrefectures={selectedPrefectures}
+            prefectures={prefectures}
+            populationData={populationData}
+            isLoading={isLoading}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './App.css';
+import LoadingDots from './components/LoadingDots';
 import PrefectureCheckboxList from './components/PrefectureCheckboxList';
 import PopulationDataDisplay from './components/PopulationDataDisplay';
 import useFetchPrefectures from './hooks/useFetchPrefectures';
@@ -11,6 +12,13 @@ const App: React.FC = () => {
   const { populationData, fetchPopulationData } = usePopulationData();
   const [populationCategory, setPopulationCategory] =
     useState<string>('総人口');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (prefectures.length > 0) {
+      setIsLoading(false);
+    }
+  }, [prefectures]);
 
   const handleCheckboxChange = (prefCode: number) => {
     setSelectedPrefectures((prevSelected) => {
@@ -38,45 +46,52 @@ const App: React.FC = () => {
   return (
     <div>
       <h1>都道府県一覧</h1>
-      <PrefectureCheckboxList
-        prefectures={prefectures}
-        selectedPrefectures={selectedPrefectures}
-        onCheckboxChange={handleCheckboxChange}
-      />
 
-      {/* カテゴリを選択するUIをボタンで表示 */}
-      <div className="category-buttons">
-        <button
-          className={populationCategory === '総人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('総人口')}
-        >
-          総人口
-        </button>
-        <button
-          className={populationCategory === '年少人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('年少人口')}
-        >
-          年少人口
-        </button>
-        <button
-          className={populationCategory === '生産年齢人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('生産年齢人口')}
-        >
-          生産年齢人口
-        </button>
-        <button
-          className={populationCategory === '老年人口' ? 'active' : ''}
-          onClick={() => handleCategoryChange('老年人口')}
-        >
-          老年人口
-        </button>
-      </div>
+      {isLoading ? (
+        <LoadingDots />
+      ) : (
+        <>
+          <PrefectureCheckboxList
+            prefectures={prefectures}
+            selectedPrefectures={selectedPrefectures}
+            onCheckboxChange={handleCheckboxChange}
+          />
 
-      <PopulationDataDisplay
-        selectedPrefectures={selectedPrefectures}
-        prefectures={prefectures}
-        populationData={populationData}
-      />
+          {/* カテゴリを選択するUIをボタンで表示 */}
+          <div className="category-buttons">
+            <button
+              className={populationCategory === '総人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('総人口')}
+            >
+              総人口
+            </button>
+            <button
+              className={populationCategory === '年少人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('年少人口')}
+            >
+              年少人口
+            </button>
+            <button
+              className={populationCategory === '生産年齢人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('生産年齢人口')}
+            >
+              生産年齢人口
+            </button>
+            <button
+              className={populationCategory === '老年人口' ? 'active' : ''}
+              onClick={() => handleCategoryChange('老年人口')}
+            >
+              老年人口
+            </button>
+          </div>
+
+          <PopulationDataDisplay
+            selectedPrefectures={selectedPrefectures}
+            prefectures={prefectures}
+            populationData={populationData}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,10 +89,6 @@ const App: React.FC = () => {
             selectedPrefectures={selectedPrefectures}
             prefectures={prefectures}
             populationData={populationData}
-<<<<<<< HEAD
-=======
-            isLoading={isLoading}
->>>>>>> e12dceacd9a83d54399b53d15fd8a802ef8e20e8
           />
         </>
       )}

--- a/src/components/LoadingDots.css
+++ b/src/components/LoadingDots.css
@@ -1,0 +1,44 @@
+.loading-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100px;
+    margin: 0 auto;
+}
+
+.dot {
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background-color: #3498db;
+    animation: jump 1s infinite ease-in-out;
+}
+
+.dot:nth-child(1) {
+    animation-delay: 0s;
+}
+
+.dot:nth-child(2) {
+    animation-delay: 0.1s;
+}
+
+.dot:nth-child(3) {
+    animation-delay: 0.2s;
+}
+
+.dot:nth-child(4) {
+    animation-delay: 0.3s;
+}
+
+.dot:nth-child(5) {
+    animation-delay: 0.4s;
+}
+
+@keyframes jump {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-15px);
+    }
+}

--- a/src/components/LoadingDots.tsx
+++ b/src/components/LoadingDots.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import './LoadingDots.css';
+
+const LoadingDots: React.FC = () => {
+  return (
+    <div className="loading-container">
+      <div className="dot"></div>
+      <div className="dot"></div>
+      <div className="dot"></div>
+      <div className="dot"></div>
+      <div className="dot"></div>
+    </div>
+  );
+};
+
+export default LoadingDots;

--- a/src/components/PopulationDataDisplay.tsx
+++ b/src/components/PopulationDataDisplay.tsx
@@ -9,6 +9,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
+import { useMediaQuery } from 'react-responsive';
 
 type PopulationData = {
   year: number;
@@ -46,6 +47,8 @@ const PopulationDataDisplay: React.FC<PopulationDataDisplayProps> = ({
   prefectures,
   populationData,
 }) => {
+  const isMobile = useMediaQuery({ query: '(max-width: 768px)' });
+  const isTablet = useMediaQuery({ query: '(max-width: 1024px)' });
   const mergedData = mergePopulationData(selectedPrefectures, populationData);
   return (
     <div>
@@ -55,8 +58,20 @@ const PopulationDataDisplay: React.FC<PopulationDataDisplayProps> = ({
       <ResponsiveContainer width="100%" height={400}>
         <LineChart data={mergedData}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="year" />
-          <YAxis />
+          <XAxis
+            dataKey="year"
+            interval={0}
+            angle={-45}
+            textAnchor="end"
+            tick={{ fontSize: isMobile ? '12px' : isTablet ? '14px' : '16px' }}
+          />
+          <YAxis
+            width={isMobile ? 30 : isTablet ? 50 : 60}
+            tickFormatter={(value) => `${value / 1000}K`}
+            tick={{
+              fontSize: isMobile ? '9px' : isTablet ? '11px' : '13px',
+            }}
+          />
           <Tooltip />
           <Legend />
           {selectedPrefectures.map((prefCode, index) => {

--- a/src/components/PopulationDataDisplay.tsx
+++ b/src/components/PopulationDataDisplay.tsx
@@ -1,4 +1,14 @@
 import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
 
 type PopulationData = {
   year: number;
@@ -11,28 +21,62 @@ type PopulationDataDisplayProps = {
   populationData: Record<number, PopulationData[]>;
 };
 
+const mergePopulationData = (
+  selectedPrefectures: number[],
+  populationData: Record<number, PopulationData[]>
+) => {
+  const mergedData: Record<number, { year: number } & Record<number, number>> =
+    {};
+  selectedPrefectures.forEach((prefCode) => {
+    const data = populationData[prefCode];
+    if (data) {
+      data.forEach((popData) => {
+        if (!mergedData[popData.year]) {
+          mergedData[popData.year] = { year: popData.year };
+        }
+        mergedData[popData.year][prefCode] = popData.value;
+      });
+    }
+  });
+  return Object.values(mergedData);
+};
+
 const PopulationDataDisplay: React.FC<PopulationDataDisplayProps> = ({
   selectedPrefectures,
   prefectures,
   populationData,
 }) => {
+  const mergedData = mergePopulationData(selectedPrefectures, populationData);
   return (
     <div>
       <h2>人口データ：</h2>
-      {selectedPrefectures.map((prefCode) => (
-        <div key={prefCode}>
-          <h3>
-            {prefectures.find((pref) => pref.prefCode === prefCode)?.prefName}
-          </h3>
-          <ul>
-            {populationData[prefCode]?.map((pop) => (
-              <li key={pop.year}>
-                {pop.year}: {pop.value}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
+      {selectedPrefectures.length === 0 && <p>都道府県を選択してください。</p>}
+
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart data={mergedData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="year" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          {selectedPrefectures.map((prefCode, index) => {
+            const prefecture = prefectures.find(
+              (pref) => pref.prefCode === prefCode
+            );
+            const color = `hsl(${index * 50}, 70%, 50%)`;
+            return (
+              <Line
+                key={prefCode}
+                type="monotone"
+                dataKey={prefCode}
+                stroke={color}
+                activeDot={{ r: 8 }}
+                name={prefecture?.prefName}
+              />
+            );
+          })}
+        </LineChart>
+      </ResponsiveContainer>
     </div>
   );
 };


### PR DESCRIPTION
## 概要
都道府県ごとの人口データをグラフで表示し、レスポンシブ対応を追加した。また、選択した人口カテゴリごとにグラフを切り替える機能も実装。

### 対応する Issue
- Closes #5 

### 実装内容
- 人口データを取得し、都道府県ごとのグラフをRechartsで表示
- 「総人口」「年少人口」「生産年齢人口」「老年人口」のカテゴリごとにグラフを切り替える機能を追加
- UIのレスポンシブ対応を強化し、モバイルやタブレットでの表示も最適化

### 受け入れ条件
- グラフ表示とレスポンシブ対応が正しく機能していること
